### PR TITLE
Don't break underscore (one_two) property names into comma seperated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <properties>
-        <neo4j.version>2.2.1</neo4j.version>
+        <neo4j.version>2.2.6</neo4j.version>
     </properties>
 
     <modelVersion>4.0.0</modelVersion>

--- a/src/main/java/org/neo4j/elasticsearch/ElasticSearchIndexSpecParser.java
+++ b/src/main/java/org/neo4j/elasticsearch/ElasticSearchIndexSpecParser.java
@@ -17,7 +17,7 @@ import org.neo4j.graphdb.Label;
 public class ElasticSearchIndexSpecParser {
     
     private final static Pattern INDEX_SPEC_RE = Pattern.compile("(?<indexname>[a-z][a-z_-]+):(?<label>[A-Za-z0-9]+)\\((?<props>[^\\)]+)\\)");
-    private final static Pattern PROPS_SPEC_RE = Pattern.compile("((?!=,)([A-Za-z0-9]+))+");
+    private final static Pattern PROPS_SPEC_RE = Pattern.compile("((?!=,)([A-Za-z0-9_]+))+");
     
     public static Map<Label, List<ElasticSearchIndexSpec>> parseIndexSpec(String spec) throws ParseException {
         if (spec == null) {


### PR DESCRIPTION
* note this also upgrades to Neo4j 2.2.6 (as 2.2.1 package was not locatable)

Neo4j allows for underscores in property names, so small addition to regex for including '_' in parsing of property names.