### PR TITLE
Added guard to prevent null exception on missing properties

### DIFF
--- a/src/main/java/org/neo4j/elasticsearch/ElasticSearchEventHandler.java
+++ b/src/main/java/org/neo4j/elasticsearch/ElasticSearchEventHandler.java
@@ -183,8 +183,10 @@ class ElasticSearchEventHandler implements TransactionEventHandler<Collection<Bu
         	json.put("labels", labels(node));
 
         for (String prop : properties) {
-            Object value = node.getProperty(prop);
-            json.put(prop, value);
+            if(node.hasProperty(prop)){
+                Object value = node.getProperty(prop);
+                json.put(prop, value);
+            }
         }
         return json;
     }

--- a/src/main/java/org/neo4j/elasticsearch/ElasticSearchIndexSpecParser.java
+++ b/src/main/java/org/neo4j/elasticsearch/ElasticSearchIndexSpecParser.java
@@ -12,7 +12,7 @@ import static java.util.Collections.singletonList;
 
 public class ElasticSearchIndexSpecParser {
     
-    private final static Pattern INDEX_SPEC_RE = Pattern.compile("(?<indexname>[a-z][a-z_-]+):(?<label>[A-Za-z0-9]+)\\((?<props>[^\\)]+)\\)");
+    private final static Pattern INDEX_SPEC_RE = Pattern.compile("(?<indexname>[a-z][a-z_-]+):(?<label>[A-Za-z0-9_]+)\\((?<props>[^\\)]+)\\)");
     private final static Pattern PROPS_SPEC_RE = Pattern.compile("((?!=,)([A-Za-z0-9_]+))+");
     
     public static Map<String, List<ElasticSearchIndexSpec>> parseIndexSpec(String spec) throws ParseException {


### PR DESCRIPTION
as per this issue: https://github.com/neo4j-contrib/neo4j-elasticsearch/issues/31 when adding nodes that have missing properties, the transaction fails because of null access exception due to lack of checks. I added a guard, now it works.